### PR TITLE
Add macOS build targets and a Homebrew formula

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,11 +52,21 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             artifact: clock-tui-linux-x86_64
             builder: cargo
+            os: ubuntu-22.04
           - target: aarch64-unknown-linux-gnu
             artifact: clock-tui-linux-aarch64
             builder: cross
+            os: ubuntu-22.04
+          - target: aarch64-apple-darwin
+            artifact: clock-tui-macos-aarch64
+            builder: cargo
+            os: macos-14
+          - target: x86_64-apple-darwin
+            artifact: clock-tui-macos-x86_64
+            builder: cargo
+            os: macos-13
 
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v5
@@ -94,7 +104,11 @@ jobs:
 
       - name: Compute SHA256
         run: |
-          SHA=$(sha256sum ${{ matrix.artifact }}.tar.gz | awk '{print $1}')
+          if command -v sha256sum >/dev/null 2>&1; then
+            SHA=$(sha256sum ${{ matrix.artifact }}.tar.gz | awk '{print $1}')
+          else
+            SHA=$(shasum -a 256 ${{ matrix.artifact }}.tar.gz | awk '{print $1}')
+          fi
           echo "$SHA  ${{ matrix.artifact }}.tar.gz" > ${{ matrix.artifact }}.tar.gz.sha256
           echo "Built ${{ matrix.artifact }}.tar.gz sha256=$SHA"
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ The recommended install method on Arch Linux is the prebuilt AUR package from th
 yay -S clock-tui-bin
 ```
 
+### macOS / Homebrew
+
+A Homebrew formula is provided in [`packaging/homebrew/tclock.rb`](packaging/homebrew/tclock.rb). It builds from source via Cargo, so it works on both Apple Silicon and Intel Macs (and Linuxbrew). Current Homebrew requires formulae to live in a tap, so add it to a local tap first:
+
+```shell
+brew tap-new "$USER/clocktui" --no-git
+cp packaging/homebrew/tclock.rb "$(brew --repository)/Library/Taps/$USER/homebrew-clocktui/Formula/"
+brew install "$USER/clocktui/tclock"
+```
+
+> Source-build keeps installation working independently of the release cadence. Once macOS release tarballs are published, the formula can be extended with prebuilt bottles for instant installs.
+
 ### GitHub Releases
 
 Prebuilt Linux binaries are published for `x86_64` and `aarch64`:

--- a/packaging/homebrew/tclock.rb
+++ b/packaging/homebrew/tclock.rb
@@ -1,0 +1,36 @@
+# typed: true
+# frozen_string_literal: true
+
+# Homebrew formula for clock-tui (binary: tclock).
+#
+# This formula builds from source via Cargo, so it works on any macOS or Linux
+# machine with a Rust toolchain available at install time (Homebrew pulls in
+# `rust` as a build dependency automatically).
+#
+# Future work — prebuilt bottles:
+#   Once the release workflow publishes macOS tarballs
+#   (clock-tui-macos-aarch64.tar.gz / clock-tui-macos-x86_64.tar.gz), this
+#   formula can be extended with a `bottle do ... end` block, or switched to a
+#   binary install that downloads the matching release asset and verifies its
+#   SHA256. Building from source is kept as the baseline so `brew install`
+#   works immediately, independent of the release cadence.
+class Tclock < Formula
+  desc "Terminal clock app with clock, timer, stopwatch, countdown, and widgets"
+  homepage "https://github.com/akitaonrails/clock-tui"
+  url "https://github.com/akitaonrails/clock-tui/archive/refs/tags/v0.6.8.tar.gz"
+  # sha256 of the source tarball above — recompute when bumping the version:
+  #   curl -fsSL <url> | shasum -a 256
+  sha256 "6b4951e812dc6da420fdb7af7b7c1245d5fd70e4902357ac59969605a2a30525"
+  license "MIT"
+  head "https://github.com/akitaonrails/clock-tui.git", branch: "master"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", "--locked", "--root", prefix, "--path", "clock-tui", "--bin", "tclock"
+  end
+
+  test do
+    assert_match "tclock", shell_output("#{bin}/tclock --help")
+  end
+end


### PR DESCRIPTION
## What & why

`clock-tui` currently ships prebuilt binaries for Linux only and has no Homebrew install path, so macOS users have no straightforward way to install `tclock`. This PR adds macOS support to the release pipeline and a Homebrew formula.

It's intentionally structured as the **foundation for prebuilt bottles**, not just a cargo wrapper:

1. **CI — macOS binaries** (`.github/workflows/release.yml`)
   - Adds `aarch64-apple-darwin` (on `macos-14`) and `x86_64-apple-darwin` (on `macos-13`) to the build matrix, native on each runner.
   - Moves runner selection into the matrix (`runs-on: ${{ matrix.os }}`) instead of a hardcoded `ubuntu-22.04`.
   - Makes the SHA256 step portable (`sha256sum` on Linux, `shasum -a 256` on macOS).
   - Result: future releases will publish `clock-tui-macos-aarch64.tar.gz` / `clock-tui-macos-x86_64.tar.gz` with checksums, in the exact same pattern as the Linux artifacts.

2. **Homebrew formula** (`packaging/homebrew/tclock.rb`)
   - Builds from source via `cargo` so `brew install` works **immediately**, independent of the release cadence — no dependency on a new tagged release existing first.
   - The header comment documents the upgrade path: once the macOS release tarballs from (1) are published, the formula can gain a `bottle do` block / binary install for instant, no-compile installs.

3. **README** — documents the macOS / Homebrew install path.

## Validation

- `release.yml` YAML structure follows the existing matrix pattern; macOS targets build natively (so tests run on them too, same as the Linux `cargo` target).
- Formula: `brew audit --new --formula` passes clean, and I verified an end-to-end `brew install` from a local tap actually compiles and runs `tclock` on Apple Silicon (macOS).
- Source tarball SHA256 pinned to the `v0.6.8` tag.

## Notes / open questions

- Current Homebrew requires formulae to live in a tap (file-path installs are rejected), so the README documents the local-tap flow. If you'd prefer, this formula could instead live in a dedicated `akitaonrails/homebrew-tap` repo — happy to adjust to whatever fits your release process.
- The version (`0.6.8`) and source SHA in the formula will need a bump per release; could be automated in the release workflow later, similar to the AUR PKGBUILD pinning step.

First-time contributor here — glad to make any changes you'd like. 🙇