### PR TITLE
feat: add widget groups cycled with `g`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,8 +23,9 @@
 
 ## Runtime gotchas
 - Config is loaded from `dirs::config_dir()/tclock/config.toml` (XDG: `$XDG_CONFIG_HOME/tclock/config.toml`, usually `~/.config/tclock/config.toml`); missing config is ignored, and invalid TOML prints an error then falls back to defaults.
-- The main key bindings are in `clock-tui/src/bin/main.rs`: `q` exits, space pauses/resumes supported modes, and `c`/`w`/`t` switch to clock/stopwatch/timer. There is no countdown switch key in the main loop.
+- The main key bindings are in `clock-tui/src/bin/main.rs`: `q` exits, space pauses/resumes supported modes, and `c`/`w`/`t` switch to clock/stopwatch/timer. There is no countdown switch key in the main loop. Clock-mode-only keys (`Shift+T` theme cycle, `g` widget-group cycle, `Home`/`End` scroll) are forwarded to `App::on_key`, which dispatches them in `clock-tui/src/app.rs`.
 - Clock widgets are config-only under `[[clock.widgets]]`, clock-mode only, implemented in `clock-tui/src/app/modes/clock_widget.rs`; widget commands run from `App::tick()` state, not from `Widget::render()`.
+- An optional `group` on a widget makes it part of a set cycled with `g`; ungrouped widgets are always visible. Group membership is filtered in `ClockWidgets::render`, which is what sets `visible`, and `tick()` skips non-visible widgets — so a hidden group costs no subprocesses.
 
 ## Tests
 - Focused unit tests exist in `clock-tui/src/config.rs` and `clock-tui/src/app/modes/clock_widget.rs`; use Cargo’s standard filter, e.g. `cargo test clock_widget --package clock-tui`.

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ The clock automatically sizes itself into the top area when widgets are configur
 
 Widgets with `position = "bottom"` are placed in a full-width band beneath the widget row instead, stacked in config order and each sized to exactly fit its output. The widget row keeps a minimum height when both are present, and a bottom widget that cannot get at least 3 rows is hidden rather than squeezed. Bottom widgets don't count against the per-row widget limits, so a status strip can coexist with a full row of columns.
 
-When a widget has more output than fits on screen, scroll it with the mouse wheel over that widget. `Home` and `End` jump the active widget to the top or bottom. In clock mode, press `Shift+T` to cycle the configured clock theme; lowercase `t` still switches to Timer mode.
+When a widget has more output than fits on screen, scroll it with the mouse wheel over that widget. `Home` and `End` jump the active widget to the top or bottom. In clock mode, press `Shift+T` to cycle the configured clock theme; lowercase `t` still switches to Timer mode. Press `g` to cycle widget groups (see [Widget groups](#widget-groups)).
 
 Each widget supports:
 
@@ -175,6 +175,7 @@ Each widget supports:
 - `refresh_secs`: refresh interval, default `900`
 - `timeout_secs`: command timeout, default `30`
 - `position`: `"auto"` (default, widget row) or `"bottom"` (full-width band below the row, sized to content)
+- `group`: optional group name; widgets in the same group are shown together and swapped as a set with `g` (see [Widget groups](#widget-groups))
 
 `widget_themes` controls the clock-mode theme cycle. For built-in app palettes (`default`, `evangelion`, and `nerv`), the app themes the clock digits, date/header text, and widget base/chrome styles itself, and also injects the current theme name into every widget subprocess as `TCLOCK_WIDGET_THEME`. `tclock --theme nerv` or `TCLOCK_WIDGET_THEME=nerv tclock` chooses the initial theme and keeps the configured cycle order after it. Other names are still passed to widget commands, but the app UI falls back to default styling unless that palette is added to `tclock` too. Theme names are a contract between your config and the widget commands: a command must understand the name it receives if it wants to match its internal ANSI palette.
 
@@ -184,6 +185,43 @@ widget_themes = ["default", "evangelion", "nerv"]
 ```
 
 An empty or single-item list makes `Shift+T` harmless. For coherent app + bundled-widget theming, keep built-in names such as `default`, `evangelion`, and `nerv` unless you also add the palette to both `tclock` and `tclock-system-health`.
+
+### Widget groups
+
+Screen space is finite, and the widget row only fits 2–6 columns depending on terminal width. Groups let you configure more widgets than fit at once and swap between them: give widgets a `group` name, and press `g` to cycle to the next group.
+
+- A widget with **no** `group` is always on screen, in every group.
+- A widget **with** a `group` is only on screen while that group is active.
+- Groups cycle in the order they first appear in the config, so **the first grouped widget decides which group is shown at startup**.
+- Switching groups keeps each widget's last output, so returning to a group is instant instead of showing `Loading...`. Hidden widgets don't refresh, so an expensive command costs nothing while it's off screen.
+- With fewer than two groups, `g` does nothing.
+
+```toml
+[clock]
+show_date = true
+
+# Always visible — has no group, so it survives every `g` press.
+[[clock.widgets]]
+title = "Google Calendar"
+command = "google-calendar-tui"
+refresh_secs = 3600
+
+# Group "weather" appears first, so it's the group shown at startup.
+[[clock.widgets]]
+title = "Weather"
+group = "weather"
+command = ["sh", "-c", "curl -s 'https://wttr.in/Florianopolis?0&Q&M'"]
+refresh_secs = 1800
+
+# Press `g` to swap the weather column out for this one.
+[[clock.widgets]]
+title = "GitHub pending"
+group = "github"
+command = "ghpending"
+refresh_secs = 900
+```
+
+To show a different region, change the location in the `wttr.in` URL — it accepts a city (`wttr.in/Curitiba`), a city with country when the name is ambiguous (`wttr.in/Porto+Alegre,BR`), an airport code (`wttr.in/GRU`), or `~` for a landmark (`wttr.in/~Cristo+Redentor`). Use `+` for spaces and drop accents. The query flags: `0` prints today only (keeping the widget short), `Q` hides the location header, `M` reports wind in m/s. Don't add `T` — it strips the ANSI colors that the widget would otherwise render. Leaving the location out entirely (`wttr.in/?0`) geolocates by IP, which behind a VPN reports the VPN's exit city.
 
 ### Bundled example: system-health widget
 

--- a/clock-tui/src/app.rs
+++ b/clock-tui/src/app.rs
@@ -324,6 +324,7 @@ impl App {
         if let Some(w) = self.clock.as_mut() {
             match key {
                 KeyCode::Char('T') => w.cycle_widget_theme(),
+                KeyCode::Char('g') => w.cycle_widget_group(),
                 KeyCode::Home => w.scroll_active_widget_to_top(),
                 KeyCode::End => w.scroll_active_widget_to_bottom(),
                 _ => {}

--- a/clock-tui/src/app/modes/clock.rs
+++ b/clock-tui/src/app/modes/clock.rs
@@ -65,6 +65,10 @@ impl Clock {
         self.widgets.cycle_theme();
     }
 
+    pub(crate) fn cycle_widget_group(&mut self) {
+        self.widgets.cycle_group();
+    }
+
     pub(crate) fn current_theme(&self) -> ClockTheme {
         self.widgets.current_clock_theme(self.style)
     }

--- a/clock-tui/src/app/modes/clock_widget.rs
+++ b/clock-tui/src/app/modes/clock_widget.rs
@@ -60,6 +60,8 @@ pub(crate) struct ClockWidgets {
     active_widget: Option<usize>,
     themes: Vec<String>,
     theme_index: usize,
+    groups: Vec<String>,
+    group_index: usize,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -143,6 +145,7 @@ struct ClockWidget {
     refresh: Duration,
     timeout: Duration,
     position: WidgetPosition,
+    group: Option<String>,
     output: String,
     running: bool,
     visible: bool,
@@ -163,6 +166,7 @@ impl ClockWidgets {
         let now = Instant::now();
         let cancel = Arc::new(AtomicBool::new(false));
         let themes = normalize_themes(themes);
+        let groups = collect_groups(&configs);
         let widgets = configs
             .into_iter()
             .map(|config| ClockWidget {
@@ -171,6 +175,7 @@ impl ClockWidgets {
                 refresh: duration_or_default(config.refresh_secs, DEFAULT_REFRESH),
                 timeout: duration_or_default(config.timeout_secs, DEFAULT_TIMEOUT),
                 position: config.position,
+                group: normalize_group(config.group.as_deref()),
                 output: "Loading...".to_string(),
                 running: false,
                 visible: false,
@@ -190,6 +195,8 @@ impl ClockWidgets {
             active_widget: None,
             themes,
             theme_index: 0,
+            groups,
+            group_index: 0,
         }
     }
 
@@ -264,6 +271,36 @@ impl ClockWidgets {
         }
     }
 
+    /// Switch to the next widget group. Widgets outside the new group stop
+    /// refreshing (they are no longer visible) but keep their last output, so
+    /// coming back to a group is instant instead of showing "Loading...".
+    pub(crate) fn cycle_group(&mut self) {
+        if self.groups.len() <= 1 {
+            return;
+        }
+
+        self.group_index = (self.group_index + 1) % self.groups.len();
+        self.active_widget = None;
+    }
+
+    fn current_group(&self) -> Option<&str> {
+        self.groups.get(self.group_index).map(String::as_str)
+    }
+
+    /// A widget is eligible for layout when it has no group (always shown) or
+    /// its group is the active one.
+    fn in_active_group(&self, widget: &ClockWidget) -> bool {
+        match widget.group.as_deref() {
+            None => true,
+            Some(group) => Some(group) == self.current_group(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn current_group_for_test(&self) -> Option<&str> {
+        self.current_group()
+    }
+
     fn current_theme(&self) -> &str {
         self.themes
             .get(self.theme_index)
@@ -299,14 +336,18 @@ impl ClockWidgets {
             .widgets
             .iter()
             .enumerate()
-            .filter(|(_, widget)| widget.position == WidgetPosition::Auto)
+            .filter(|(_, widget)| {
+                widget.position == WidgetPosition::Auto && self.in_active_group(widget)
+            })
             .map(|(index, _)| index)
             .collect();
         let bottom_indices: Vec<usize> = self
             .widgets
             .iter()
             .enumerate()
-            .filter(|(_, widget)| widget.position == WidgetPosition::Bottom)
+            .filter(|(_, widget)| {
+                widget.position == WidgetPosition::Bottom && self.in_active_group(widget)
+            })
             .map(|(index, _)| index)
             .collect();
 
@@ -521,6 +562,28 @@ fn normalize_themes(themes: Vec<String>) -> Vec<String> {
         .map(|theme| theme.trim().to_string())
         .filter(|theme| !theme.is_empty())
         .collect()
+}
+
+/// Trim a configured group name, treating blank as "no group".
+fn normalize_group(group: Option<&str>) -> Option<String> {
+    group
+        .map(str::trim)
+        .filter(|group| !group.is_empty())
+        .map(str::to_string)
+}
+
+/// Group cycle order is the order groups first appear in the config, so the
+/// first grouped widget decides which group is shown at startup.
+fn collect_groups(configs: &[ClockWidgetConfig]) -> Vec<String> {
+    let mut groups: Vec<String> = Vec::new();
+    for config in configs {
+        if let Some(group) = normalize_group(config.group.as_deref()) {
+            if !groups.contains(&group) {
+                groups.push(group);
+            }
+        }
+    }
+    groups
 }
 
 fn run_command(
@@ -973,6 +1036,7 @@ mod tests {
                     refresh_secs: DEFAULT_WIDGET_REFRESH_SECS,
                     timeout_secs: DEFAULT_WIDGET_TIMEOUT_SECS,
                     position: WidgetPosition::Auto,
+                    group: None,
                 },
                 ClockWidgetConfig {
                     title: None,
@@ -980,6 +1044,7 @@ mod tests {
                     refresh_secs: DEFAULT_WIDGET_REFRESH_SECS,
                     timeout_secs: DEFAULT_WIDGET_TIMEOUT_SECS,
                     position: WidgetPosition::Auto,
+                    group: None,
                 },
                 ClockWidgetConfig {
                     title: None,
@@ -987,6 +1052,7 @@ mod tests {
                     refresh_secs: DEFAULT_WIDGET_REFRESH_SECS,
                     timeout_secs: DEFAULT_WIDGET_TIMEOUT_SECS,
                     position: WidgetPosition::Auto,
+                    group: None,
                 },
             ],
             default_themes(),
@@ -1186,6 +1252,104 @@ mod tests {
         assert!(height <= area.height);
     }
 
+    #[test]
+    fn groups_cycle_in_first_appearance_order() {
+        let mut widgets = ClockWidgets::new(
+            vec![
+                grouped_widget_config("weather", Some("weather")),
+                grouped_widget_config("github", Some("github")),
+                grouped_widget_config("forecast", Some("weather")),
+            ],
+            default_themes(),
+        );
+
+        // First group in config order is the one shown at startup.
+        assert_eq!(widgets.current_group_for_test(), Some("weather"));
+
+        widgets.cycle_group();
+        assert_eq!(widgets.current_group_for_test(), Some("github"));
+
+        // Only two distinct groups, so it wraps back rather than visiting
+        // "weather" twice for the two weather widgets.
+        widgets.cycle_group();
+        assert_eq!(widgets.current_group_for_test(), Some("weather"));
+    }
+
+    #[test]
+    fn render_shows_active_group_and_always_shows_ungrouped() {
+        let mut widgets = ClockWidgets::new(
+            vec![
+                grouped_widget_config("weather", Some("weather")),
+                grouped_widget_config("github", Some("github")),
+                grouped_widget_config("calendar", None),
+            ],
+            default_themes(),
+        );
+        let area = Rect::new(0, 0, 80, 30);
+        let mut buffer = Buffer::empty(area);
+
+        widgets.render(area, area, &mut buffer, default_clock_theme());
+        assert!(widgets.widgets[0].visible, "active group is rendered");
+        assert!(!widgets.widgets[1].visible, "inactive group is hidden");
+        assert!(widgets.widgets[2].visible, "ungrouped is always rendered");
+
+        widgets.cycle_group();
+        widgets.render(area, area, &mut buffer, default_clock_theme());
+        assert!(!widgets.widgets[0].visible);
+        assert!(widgets.widgets[1].visible);
+        assert!(widgets.widgets[2].visible);
+    }
+
+    #[test]
+    fn hidden_group_keeps_its_output_across_a_cycle() {
+        let mut widgets = ClockWidgets::new(
+            vec![
+                grouped_widget_config("weather", Some("weather")),
+                grouped_widget_config("github", Some("github")),
+            ],
+            default_themes(),
+        );
+        widgets.widgets[0].output = "22C sunny".to_string();
+
+        widgets.cycle_group();
+        widgets.cycle_group();
+
+        // Unlike a theme cycle, switching groups must not reset output to
+        // "Loading..." — returning to a group should be instant.
+        assert_eq!(widgets.widgets[0].output, "22C sunny");
+    }
+
+    #[test]
+    fn cycling_is_inert_without_at_least_two_groups() {
+        let mut widgets = ClockWidgets::new(
+            vec![widget_config("a"), widget_config("b")],
+            default_themes(),
+        );
+        let area = Rect::new(0, 0, 80, 30);
+        let mut buffer = Buffer::empty(area);
+
+        widgets.cycle_group();
+
+        assert_eq!(widgets.current_group_for_test(), None);
+        widgets.render(area, area, &mut buffer, default_clock_theme());
+        assert!(widgets.widgets.iter().all(|widget| widget.visible));
+    }
+
+    #[test]
+    fn blank_group_is_treated_as_ungrouped() {
+        let widgets = ClockWidgets::new(
+            vec![
+                grouped_widget_config("spaces", Some("   ")),
+                grouped_widget_config("real", Some("  github  ")),
+            ],
+            default_themes(),
+        );
+
+        assert_eq!(widgets.widgets[0].group, None);
+        assert_eq!(widgets.widgets[1].group.as_deref(), Some("github"));
+        assert_eq!(widgets.groups, vec!["github".to_string()]);
+    }
+
     fn widget_config(title: &str) -> ClockWidgetConfig {
         ClockWidgetConfig {
             title: Some(title.to_string()),
@@ -1193,6 +1357,14 @@ mod tests {
             refresh_secs: DEFAULT_WIDGET_REFRESH_SECS,
             timeout_secs: DEFAULT_WIDGET_TIMEOUT_SECS,
             position: WidgetPosition::Auto,
+            group: None,
+        }
+    }
+
+    fn grouped_widget_config(title: &str, group: Option<&str>) -> ClockWidgetConfig {
+        ClockWidgetConfig {
+            group: group.map(str::to_string),
+            ..widget_config(title)
         }
     }
 

--- a/clock-tui/src/app/modes/clock_widget.rs
+++ b/clock-tui/src/app/modes/clock_widget.rs
@@ -232,8 +232,13 @@ impl ClockWidgets {
         }
 
         let theme = self.current_theme().to_string();
+        let current_group = self.current_group().map(str::to_string);
         for (index, widget) in self.widgets.iter_mut().enumerate() {
-            if !widget.visible || widget.running || now < widget.next_run {
+            let in_active_group = match widget.group.as_deref() {
+                None => true,
+                Some(group) => current_group.as_deref() == Some(group),
+            };
+            if !widget.visible || !in_active_group || widget.running || now < widget.next_run {
                 continue;
             }
 
@@ -1317,6 +1322,27 @@ mod tests {
         // Unlike a theme cycle, switching groups must not reset output to
         // "Loading..." — returning to a group should be instant.
         assert_eq!(widgets.widgets[0].output, "22C sunny");
+    }
+
+    #[test]
+    fn cycling_group_before_render_does_not_refresh_previous_group() {
+        let mut widgets = ClockWidgets::new(
+            vec![
+                grouped_widget_config("weather", Some("weather")),
+                grouped_widget_config("github", Some("github")),
+            ],
+            default_themes(),
+        );
+
+        widgets.widgets[0].visible = true;
+        assert_eq!(widgets.current_group_for_test(), Some("weather"));
+
+        widgets.cycle_group();
+        widgets.tick();
+
+        assert_eq!(widgets.current_group_for_test(), Some("github"));
+        assert!(!widgets.widgets[0].running);
+        assert!(!widgets.widgets[1].running);
     }
 
     #[test]

--- a/clock-tui/src/bin/main.rs
+++ b/clock-tui/src/bin/main.rs
@@ -83,7 +83,9 @@ fn main() -> Result<(), Box<dyn Error>> {
                         auto_quit: false,
                         execute: vec![],
                     }),
-                    KeyCode::Char('T') | KeyCode::Home | KeyCode::End => app.on_key(key.code),
+                    KeyCode::Char('T') | KeyCode::Char('g') | KeyCode::Home | KeyCode::End => {
+                        app.on_key(key.code)
+                    }
                     _ => {}
                 },
                 Event::Mouse(mouse) => match mouse.kind {

--- a/clock-tui/src/config.rs
+++ b/clock-tui/src/config.rs
@@ -98,6 +98,12 @@ pub struct ClockWidgetConfig {
     pub timeout_secs: u64,
     #[serde(default)]
     pub position: WidgetPosition,
+    /// Optional group name. Widgets sharing a group are shown together, and
+    /// only one group is on screen at a time (cycled with `g`). Widgets with no
+    /// group are always shown. Group order follows first appearance in config,
+    /// so the first grouped widget's group is the one shown at startup.
+    #[serde(default)]
+    pub group: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
## Problem

The widget row fits 2–6 columns depending on terminal width (`visible_widget_count`). Configuring more widgets than that silently drops the overflow — there's no way to reach them. I hit this wanting a weather widget *and* `ghpending` *and* `google-calendar-tui` on a laptop-width terminal.

## What this does

Adds an optional `group` to `[[clock.widgets]]`. Widgets sharing a group show together; `g` cycles to the next group; ungrouped widgets stay on screen in every group.

```toml
# Always visible — no group.
[[clock.widgets]]
title = "Google Calendar"
command = "google-calendar-tui"

# First group in config order => shown at startup.
[[clock.widgets]]
title = "Weather"
group = "weather"
command = ["sh", "-c", "curl -s 'https://wttr.in/Florianopolis?0&Q&M'"]

# `g` swaps the weather column out for this one.
[[clock.widgets]]
title = "GitHub pending"
group = "github"
command = "ghpending"
```

## Design notes

- **No new config key for the default group.** Cycle order is first-appearance order in config, so the first grouped widget defines the startup group. Avoids a `widget_groups` list that could typo into matching nothing.
- **Hidden groups are free.** Group membership is filtered in `ClockWidgets::render` (which is what sets `visible`), and `tick()` already skips non-visible widgets — so an off-screen group spawns no subprocesses.
- **Output is retained across a switch**, unlike `cycle_theme` which resets to `Loading...` on purpose. Returning to a group is instant; a stale value is better than a spinner here since the widget keeps its normal refresh cadence once shown again.
- **Fully backward compatible.** `group` defaults to `None`; a config with no groups behaves exactly as before and `g` is inert.
- Blank/whitespace group names normalize to "no group", mirroring `normalize_themes`.

## Testing

5 unit tests added (58 pass total): first-appearance ordering + wrap, render filtering incl. ungrouped-always-visible, output retention across a cycle, inert with <2 groups, blank-name normalization.

Also verified interactively under tmux at 150x40, reading real screen state via `capture-pane`:

| | on screen |
|---|---|
| startup | `WEATHER` + `ALWAYS` |
| after `g` | `GITHUB` + `ALWAYS` |
| after `g` | `WEATHER` + `ALWAYS` (wraps) |

Full CI parity green: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo build --locked`, `cargo test --locked`, `cargo xtask` + `git diff --exit-code assets/gen` (no drift — no CLI surface changed).

Docs updated in `README.md` (new "Widget groups" section, keybinding mention, `group` in the widget field list) and `AGENTS.md` (the keybinding note listed `q`/space/`c`/`w`/`t` but not the clock-mode-only keys, so I noted those too).

## Open questions

- `g` was free, but happy to move it (`Tab`? `Shift+G`?) if you'd rather reserve single letters for modes.
- Could show a group indicator (e.g. `weather (1/2)`) near the date if you want the affordance discoverable — left it out to keep the diff focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BhL5XcXM24abHtEK7Kk3J5