### PR TITLE
feat: honor ~/.config and $XDG_CONFIG_HOME for config on all platforms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@
 - `clock-tui/Cargo.toml` has cargo-binstall metadata pointing at GitHub Release tarballs; if artifact names change, update that metadata too.
 
 ## Runtime gotchas
-- Config is loaded from `dirs::config_dir()/tclock/config.toml` (XDG: `$XDG_CONFIG_HOME/tclock/config.toml`, usually `~/.config/tclock/config.toml`); missing config is ignored, and invalid TOML prints an error then falls back to defaults.
+- Config is loaded from the first existing candidate in this order: absolute `$XDG_CONFIG_HOME/tclock/config.toml`, `~/.config/tclock/config.toml`, then `dirs::config_dir()/tclock/config.toml` as the OS-native fallback. Duplicate paths are removed; missing config is ignored, and invalid TOML prints an error then falls back to defaults.
 - The main key bindings are in `clock-tui/src/bin/main.rs`: `q` exits, space pauses/resumes supported modes, and `c`/`w`/`t` switch to clock/stopwatch/timer. There is no countdown switch key in the main loop. Clock-mode-only keys (`Shift+T` theme cycle, `g` widget-group cycle, `Home`/`End` scroll) are forwarded to `App::on_key`, which dispatches them in `clock-tui/src/app.rs`.
 - Clock widgets are config-only under `[[clock.widgets]]`, clock-mode only, implemented in `clock-tui/src/app/modes/clock_widget.rs`; widget commands run from `App::tick()` state, not from `Widget::render()`.
 - An optional `group` on a widget makes it part of a set cycled with `g`; ungrouped widgets are always visible. Group membership is filtered in `ClockWidgets::render`, which is what sets `visible`, and `tick()` skips non-visible widgets — so a hidden group costs no subprocesses.

--- a/README.md
+++ b/README.md
@@ -119,17 +119,17 @@ tclock countdown --time 2026-01-01 --title 'New Year 2026'
 
 ## Configuration
 
-`tclock` reads config from the XDG config path:
+`tclock` reads the first config file it finds in this order:
 
 ```text
-$XDG_CONFIG_HOME/tclock/config.toml
-```
-
-That is usually:
-
-```text
+$XDG_CONFIG_HOME/tclock/config.toml  # when XDG_CONFIG_HOME is absolute
 ~/.config/tclock/config.toml
+<OS-native config dir>/tclock/config.toml
 ```
+
+The OS-native fallback preserves existing setups, such as
+`~/Library/Application Support/tclock/config.toml` on macOS. Duplicate paths
+are checked only once.
 
 Missing config is ignored. Invalid TOML prints an error and falls back to defaults.
 

--- a/clock-tui/examples/config.toml
+++ b/clock-tui/examples/config.toml
@@ -1,5 +1,7 @@
 # Default configuration file for tclock
-# Copy this file to ~/.config/tclock/config.toml to enable configuration
+# Copy this file to ~/.config/tclock/config.toml to enable configuration.
+# tclock also checks $XDG_CONFIG_HOME/tclock/config.toml and, as a fallback,
+# the OS-native config dir (e.g. ~/Library/Application Support/tclock on macOS).
 
 # Global default settings
 [default]

--- a/clock-tui/examples/config.toml
+++ b/clock-tui/examples/config.toml
@@ -1,7 +1,8 @@
 # Default configuration file for tclock
-# Copy this file to ~/.config/tclock/config.toml to enable configuration.
-# tclock also checks $XDG_CONFIG_HOME/tclock/config.toml and, as a fallback,
-# the OS-native config dir (e.g. ~/Library/Application Support/tclock on macOS).
+# Copy this file to one of the locations below; tclock checks them in order:
+#   $XDG_CONFIG_HOME/tclock/config.toml (when XDG_CONFIG_HOME is absolute)
+#   ~/.config/tclock/config.toml
+#   OS-native config dir/tclock/config.toml (fallback for existing setups)
 
 # Global default settings
 [default]

--- a/clock-tui/src/config.rs
+++ b/clock-tui/src/config.rs
@@ -218,13 +218,52 @@ fn default_widget_themes() -> Vec<String> {
 }
 
 impl Config {
+    /// Ordered list of locations to look for the config file, highest priority
+    /// first. `$XDG_CONFIG_HOME` and `~/.config` are honored on every platform
+    /// (so the same `~/.config/tclock/config.toml` works on macOS and Linux),
+    /// with the OS-native directory (`~/Library/Application Support` on macOS)
+    /// kept as a fallback for existing setups. Duplicates are removed so the
+    /// same file is never read twice.
+    pub fn config_paths() -> Vec<PathBuf> {
+        let mut dirs = Vec::new();
+        if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
+            if !xdg.is_empty() {
+                dirs.push(PathBuf::from(xdg));
+            }
+        }
+        if let Some(home) = dirs::home_dir() {
+            dirs.push(home.join(".config"));
+        }
+        if let Some(native) = dirs::config_dir() {
+            dirs.push(native);
+        }
+
+        let mut paths = Vec::new();
+        for dir in dirs {
+            let path = dir.join("tclock").join("config.toml");
+            if !paths.contains(&path) {
+                paths.push(path);
+            }
+        }
+        paths
+    }
+
+    /// The config path tclock reads: the first candidate that exists, or the
+    /// highest-priority candidate as a default when none exist yet.
     pub fn config_path() -> Option<PathBuf> {
-        dirs::config_dir().map(|dir| dir.join("tclock").join("config.toml"))
+        let paths = Self::config_paths();
+        paths
+            .iter()
+            .find(|path| path.exists())
+            .cloned()
+            .or_else(|| paths.into_iter().next())
     }
 
     pub fn load() -> Option<Self> {
-        let config_path = Self::config_path()?;
-        Self::load_from_path(config_path)
+        Self::config_paths()
+            .into_iter()
+            .find(|path| path.exists())
+            .and_then(Self::load_from_path)
     }
 
     pub fn load_from_path(path: impl AsRef<Path>) -> Option<Self> {
@@ -318,5 +357,34 @@ mod tests {
         assert_eq!(widget.command, vec!["sh", "-c", "printf ok"]);
         assert_eq!(widget.refresh_secs, 5);
         assert_eq!(widget.timeout_secs, 2);
+    }
+
+    #[test]
+    fn config_paths_are_unique_and_target_tclock_config() {
+        let paths = Config::config_paths();
+        assert!(!paths.is_empty());
+        for path in &paths {
+            assert!(path.ends_with("tclock/config.toml"), "unexpected {path:?}");
+        }
+        let mut deduped = paths.clone();
+        deduped.dedup();
+        assert_eq!(paths, deduped, "config_paths should not contain duplicates");
+    }
+
+    #[test]
+    fn config_paths_prefer_xdg_config_home() {
+        // Safe because tests in this module do not otherwise read this var.
+        let previous = std::env::var_os("XDG_CONFIG_HOME");
+        std::env::set_var("XDG_CONFIG_HOME", "/tmp/xdg-tclock-test");
+        let paths = Config::config_paths();
+        match previous {
+            Some(value) => std::env::set_var("XDG_CONFIG_HOME", value),
+            None => std::env::remove_var("XDG_CONFIG_HOME"),
+        }
+
+        assert_eq!(
+            paths.first().map(PathBuf::as_path),
+            Some(Path::new("/tmp/xdg-tclock-test/tclock/config.toml")),
+        );
     }
 }

--- a/clock-tui/src/config.rs
+++ b/clock-tui/src/config.rs
@@ -218,23 +218,19 @@ fn default_widget_themes() -> Vec<String> {
 }
 
 impl Config {
-    /// Ordered list of locations to look for the config file, highest priority
-    /// first. `$XDG_CONFIG_HOME` and `~/.config` are honored on every platform
-    /// (so the same `~/.config/tclock/config.toml` works on macOS and Linux),
-    /// with the OS-native directory (`~/Library/Application Support` on macOS)
-    /// kept as a fallback for existing setups. Duplicates are removed so the
-    /// same file is never read twice.
-    pub fn config_paths() -> Vec<PathBuf> {
+    fn config_paths_from_dirs(
+        xdg_config_home: Option<PathBuf>,
+        home_dir: Option<PathBuf>,
+        native_config_dir: Option<PathBuf>,
+    ) -> Vec<PathBuf> {
         let mut dirs = Vec::new();
-        if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
-            if !xdg.is_empty() {
-                dirs.push(PathBuf::from(xdg));
-            }
+        if let Some(xdg) = xdg_config_home.filter(|path| path.is_absolute()) {
+            dirs.push(xdg);
         }
-        if let Some(home) = dirs::home_dir() {
+        if let Some(home) = home_dir {
             dirs.push(home.join(".config"));
         }
-        if let Some(native) = dirs::config_dir() {
+        if let Some(native) = native_config_dir {
             dirs.push(native);
         }
 
@@ -246,6 +242,21 @@ impl Config {
             }
         }
         paths
+    }
+
+    /// Ordered list of locations to look for the config file, highest priority
+    /// first. An absolute `$XDG_CONFIG_HOME` and `~/.config` are honored on
+    /// every platform (so the same `~/.config/tclock/config.toml` works on
+    /// macOS and Linux), with the OS-native directory
+    /// (`~/Library/Application Support` on macOS) kept as a fallback for
+    /// existing setups. Duplicates are removed so the same file is never read
+    /// twice.
+    pub fn config_paths() -> Vec<PathBuf> {
+        Self::config_paths_from_dirs(
+            std::env::var_os("XDG_CONFIG_HOME").map(PathBuf::from),
+            dirs::home_dir(),
+            dirs::config_dir(),
+        )
     }
 
     /// The config path tclock reads: the first candidate that exists, or the
@@ -360,31 +371,42 @@ mod tests {
     }
 
     #[test]
-    fn config_paths_are_unique_and_target_tclock_config() {
-        let paths = Config::config_paths();
-        assert!(!paths.is_empty());
-        for path in &paths {
-            assert!(path.ends_with("tclock/config.toml"), "unexpected {path:?}");
-        }
-        let mut deduped = paths.clone();
-        deduped.dedup();
-        assert_eq!(paths, deduped, "config_paths should not contain duplicates");
+    fn config_paths_prefer_absolute_xdg_and_remove_duplicates() {
+        let root = std::env::current_dir().unwrap();
+        let xdg = root.join("xdg");
+        let home = root.join("home");
+        let paths = Config::config_paths_from_dirs(
+            Some(xdg.clone()),
+            Some(home.clone()),
+            Some(xdg.clone()),
+        );
+
+        assert_eq!(
+            paths,
+            vec![
+                xdg.join("tclock").join("config.toml"),
+                home.join(".config").join("tclock").join("config.toml"),
+            ]
+        );
     }
 
     #[test]
-    fn config_paths_prefer_xdg_config_home() {
-        // Safe because tests in this module do not otherwise read this var.
-        let previous = std::env::var_os("XDG_CONFIG_HOME");
-        std::env::set_var("XDG_CONFIG_HOME", "/tmp/xdg-tclock-test");
-        let paths = Config::config_paths();
-        match previous {
-            Some(value) => std::env::set_var("XDG_CONFIG_HOME", value),
-            None => std::env::remove_var("XDG_CONFIG_HOME"),
-        }
+    fn config_paths_ignore_relative_xdg_config_home() {
+        let root = std::env::current_dir().unwrap();
+        let home = root.join("home");
+        let native = root.join("native");
+        let paths = Config::config_paths_from_dirs(
+            Some(PathBuf::from("relative")),
+            Some(home.clone()),
+            Some(native.clone()),
+        );
 
         assert_eq!(
-            paths.first().map(PathBuf::as_path),
-            Some(Path::new("/tmp/xdg-tclock-test/tclock/config.toml")),
+            paths,
+            vec![
+                home.join(".config").join("tclock").join("config.toml"),
+                native.join("tclock").join("config.toml"),
+            ]
         );
     }
 }


### PR DESCRIPTION
tclock resolved its config path only through dirs::config_dir(), which on
macOS points at ~/Library/Application Support/tclock, so a config placed at
~/.config/tclock/config.toml (as the example file's comment suggests) was
silently ignored.

Look up the config through an ordered candidate list instead: $XDG_CONFIG_HOME,
then ~/.config, then the OS-native dir as a fallback for existing setups.
Duplicate paths are removed so the same file is never read twice.

Also document the lookup order in the example config and add tests covering
path uniqueness and $XDG_CONFIG_HOME precedence.
