### PR TITLE
Fix portable widget process-group termination

### DIFF
--- a/clock-tui/src/app/modes/clock_widget.rs
+++ b/clock-tui/src/app/modes/clock_widget.rs
@@ -1032,6 +1032,9 @@ fn terminate_process_group(pid: u32) {
 fn silent_kill(signal: &str, process_group: &str) -> bool {
     Command::new("kill")
         .arg(signal)
+        // procps `kill` treats a negative PID as another option without this
+        // separator, which can signal the caller's process group instead.
+        .arg("--")
         .arg(process_group)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -1787,6 +1790,14 @@ mod tests {
         );
 
         assert_eq!(output, "nerv");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn process_group_signal_treats_negative_pid_as_an_operand() {
+        // This group is outside practical OS PID ranges. On procps `kill`,
+        // omitting `--` here signals the surrounding test process group.
+        assert!(!silent_kill("-TERM", "-2147483647"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- pass `--` before negative process-group IDs when invoking `kill`
- prevent procps `kill` from signaling the caller process group on Ubuntu
- add a Unix regression test for negative PID operand parsing

## Verification
- full local CI parity (71 tests)
- release-profile popup cancellation tests
- cargo audit and gitleaks clean
- reproduced the old and fixed parsing behavior on Ubuntu 22.04